### PR TITLE
feat(ci): Trigger PyPI publish on git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: Test and Publish
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
 
 jobs:
   test:
@@ -53,6 +56,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     environment: pypi
+    # Only publish on tags that start with v
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Modifies the GitHub Actions workflow (`.github/workflows/ci.yml`) to change the publishing trigger.

Previously, the workflow would attempt to publish to PyPI on every push to the `main` branch. This has been changed to only publish when a git tag starting with `v` (e.g., `v1.2.3`) is pushed.

The `test` job will continue to run on pushes to `main` to ensure the branch integrity. This change gives maintainers manual control over the release process.