### PR TITLE
ci: Update pypa/gh-action-pypi-publish to release/v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
 
     - name: Publish package
       if: steps.check_version.outputs.skip == 'false'
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The previous commit hash was causing issues with trusted publishing. Updating to the latest stable release of the action resolves this by correctly using OIDC for authentication with PyPI.