### PR TITLE
fix: Remove direct URL dependency to allow PyPI publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ openai = "^1.3.0"
 anthropic = "^0.23.0"
 google-generativeai = "^0.3.0"
 ollama = "^0.1.0"
-en-core-web-sm = {url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
Removed the 'en-core-web-sm' dependency from pyproject.toml. Direct URL dependencies are not allowed for packages published to PyPI and were causing the publishing workflow to fail.

Users are instructed in the README.md to download this model separately via 'spacy download'.