### PR TITLE
Fix Windows installation issue by specifying numpy dependency and add…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ python -m spacy download en_core_web_sm
 
 This project uses [Poetry](https://python-poetry.org/) for dependency management and packaging.
 
+**Windows Users**: Some dependencies, like `numpy`, may require C++ compiler tools to be installed on your system. If you encounter installation errors related to a missing C++ compiler, please install the [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+
 1.  **Clone the repository:**
     ```bash
     git clone https://github.com/GowthamRao/py_name_entity_recognition.git

--- a/poetry.lock
+++ b/poetry.lock
@@ -4543,4 +4543,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "24e6f0237d1146b783fda9aeada60e75ae0f535b8b0dd77d9b46350dedce74e7"
+content-hash = "eac1eaee7914f3278f7a5ba18c67000dfba44ef579f92cae690daa2c1d883403"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pyyaml = "^6.0"
 pandas = "^2.0"
 datasets = "^2.14.0"
 Jinja2 = "^3.1.0"
+numpy = ">=1.22.4,<2.0.0"
 # For model providers
 openai = "^1.3.0"
 anthropic = "^0.23.0"


### PR DESCRIPTION
…ing a note about build tools

This change addresses an installation issue on Windows where `numpy` fails to build from source due to a missing C++ compiler.

The fix includes two parts:
1.  `numpy` is now an explicit dependency in `pyproject.toml`. This helps `poetry` and `pip` to better resolve and find pre-compiled wheels for `numpy` if they are available for the user's platform.
2.  A note has been added to the `README.md` to inform Windows users that they may need to install the Microsoft C++ Build Tools if they encounter a compiler error during installation. This provides a clear path to resolution for users who are in an environment where a pre-compiled wheel for `numpy` is not available.