### PR TITLE
CI: Add Windows and macOS to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
The test suite is now configured to run on a matrix of operating systems:
- ubuntu-latest
- windows-latest
- macos-latest

This will ensure that the package is tested across all major platforms, preventing OS-specific regressions.

The `fail-fast` strategy is set to `false` to allow all jobs in the matrix to complete, even if one fails.