### PR TITLE
feat: Add OS classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ readme = "README.md"
 homepage = "https://github.com/GowthamRao/py_name_entity_recognition"
 repository = "https://github.com/GowthamRao/py_name_entity_recognition"
 keywords = ["ner", "named entity recognition", "llm", "langchain", "langgraph", "nlp"]
+classifiers = [
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux"
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
This commit adds Operating System classifiers to the `pyproject.toml` file to explicitly declare support for macOS, Windows, and Linux.

While the package was already being tested across these platforms in the CI pipeline, this change makes the multi-OS support official in the package metadata.