### PR TITLE
Fix PyPI publishing error and update repository URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "py_name_entity_recognition"
-version = "1.0.0"
+version = "1.0.1"
 description = "LLM-based Named Entity Recognition using LangChain and LangGraph"
 authors = ["Gowtham Rao <rao@ohdsi.org>"]
 license = "Apache-2.0"
 readme = "README.md"
-homepage = "https://github.com/GowthamRao/py_name_entity_recognition"
-repository = "https://github.com/GowthamRao/py_name_entity_recognition"
+homepage = "https://github.com/OHDSI/py_name_entity_recognition"
+repository = "https://github.com/OHDSI/py_name_entity_recognition"
 keywords = ["ner", "named entity recognition", "llm", "langchain", "langgraph", "nlp"]
 classifiers = [
     "Operating System :: MacOS",


### PR DESCRIPTION
The PyPI publishing workflow was failing with a "File already exists" error. This was because the version number had not been incremented after a previous release.

This change increments the package version in `pyproject.toml` from 1.0.0 to 1.0.1 to allow for a new release to be published.

Additionally, the `homepage` and `repository` URLs in `pyproject.toml` were pointing to a fork. This has been corrected to point to the official OHDSI repository.