### PR TITLE
Fix(ci): Synchronize package version from git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,23 +77,15 @@ jobs:
       run: |
         pip install poetry
 
-    - name: Check if version is already published
-      id: check_version
+    - name: Set version from tag
       run: |
-        PACKAGE_NAME="py_name_entity_recognition"
-        PACKAGE_VERSION=$(poetry version --short)
-        if pip index versions $PACKAGE_NAME 2>/dev/null | grep -q $PACKAGE_VERSION; then
-          echo "Version $PACKAGE_VERSION of $PACKAGE_NAME is already published."
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "Version $PACKAGE_VERSION of $PACKAGE_NAME is not yet published."
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
+        # The GITHUB_REF is in the format 'refs/tags/vX.Y.Z'
+        # We extract X.Y.Z
+        VERSION=${GITHUB_REF#refs/tags/v}
+        poetry version $VERSION
     - name: Build package
-      if: steps.check_version.outputs.skip == 'false'
       run: |
         poetry build
 
     - name: Publish package
-      if: steps.check_version.outputs.skip == 'false'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The previous workflow did not automatically update the package version in `pyproject.toml` before publishing. This meant that if a new git tag was pushed without a corresponding manual update to the version file, the workflow would attempt to publish a version that already existed on PyPI, causing the publish job to fail.

This change modifies the `publish` job in the GitHub Actions workflow to:
1. Extract the version number from the git tag (e.g., `v1.2.3` -> `1.2.3`).
2. Use `poetry version` to update the `pyproject.toml` file with this new version.
3. Remove the unreliable pre-check for the version's existence on PyPI.

This ensures that the package version is always synchronized with the git tag, making the release process more robust and reliable.