### PR TITLE
Fix workflow failure (#24)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3988,6 +3988,18 @@ docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
 testing = ["black (==22.3)", "datasets", "numpy", "pytest", "pytest-asyncio", "requests", "ruff"]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+groups = ["main"]
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 description = "A lil' TOML parser"
@@ -4543,4 +4555,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "076254f04ad716b53d3bc30c23f702aae9ed949abe12857f3a0e8558b0a11713"
+content-hash = "8f4bdcb8b0f7a4ff9065d64c4bd66e3fbf402542d192c9eeb0da9a99a3e790df"

--- a/py_name_entity_recognition/__init__.py
+++ b/py_name_entity_recognition/__init__.py
@@ -6,9 +6,19 @@ agentic, and self-refining extraction workflows. It includes a comprehensive cat
 of predefined schemas for scientific and biomedical text.
 """
 
-from importlib import metadata
+import os
+import toml
 
-__version__ = metadata.version("py_name_entity_recognition")
+# Correctly locate pyproject.toml relative to the current file
+# __file__ -> /app/py_name_entity_recognition/__init__.py
+# os.path.dirname(__file__) -> /app/py_name_entity_recognition
+# os.path.dirname(os.path.dirname(__file__)) -> /app
+pyproject_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'pyproject.toml')
+
+with open(pyproject_path, 'r') as f:
+    pyproject_data = toml.load(f)
+
+__version__ = pyproject_data['tool']['poetry']['version']
 
 # Expose the primary user-facing function for easy access.
 # Expose the catalog features for schema customization and extension.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ pandas = "^2.0"
 datasets = "^2.14.0"
 Jinja2 = "^3.1.0"
 numpy = ">=1.22.4,<2.0.0"
+toml = "^0.10.2"
 # For model providers
 openai = "^1.3.0"
 anthropic = "^0.23.0"


### PR DESCRIPTION
* fix: Hardcode version to fix workflow failure

The previous method of dynamically retrieving the version using `importlib.metadata.version()` was causing the workflow to fail because the package was not installed in editable mode during the test run. This change hardcodes the version number in `py_name_entity_recognition/__init__.py` to avoid this issue.

* refactor: Read version from pyproject.toml at runtime

This change refactors the way the package version is retrieved. Instead of relying on `importlib.metadata`, which requires the package to be installed, the version is now read directly from `pyproject.toml` at runtime.

This approach ensures that the version is always consistent with `pyproject.toml` and avoids `PackageNotFoundError` in environments where the package is not installed in editable mode, such as the GitHub Actions workflow.

This addresses the user's feedback to maintain a single source of truth for the version number.