### PR TITLE
[fix] refractor version handling and fix top_p assignment for AzureChatOpenAI

### DIFF
--- a/py_name_entity_recognition/__init__.py
+++ b/py_name_entity_recognition/__init__.py
@@ -5,26 +5,12 @@ This package leverages LangChain for LLM orchestration and LangGraph for creatin
 agentic, and self-refining extraction workflows. It includes a comprehensive catalog
 of predefined schemas for scientific and biomedical text.
 """
-
-import os
-
-import toml
+from importlib.metadata import version
 
 from .catalog import PRESETS, get_schema, register_entity
 from .data_handling.io import extract_entities
 
-# Correctly locate pyproject.toml relative to the current file
-# __file__ -> /app/py_name_entity_recognition/__init__.py
-# os.path.dirname(__file__) -> /app/py_name_entity_recognition
-# os.path.dirname(os.path.dirname(__file__)) -> /app
-pyproject_path = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), "pyproject.toml"
-)
-
-with open(pyproject_path) as f:
-    pyproject_data = toml.load(f)
-
-__version__ = pyproject_data["tool"]["poetry"]["version"]
+__version__ = version("py_name_entity_recognition")
 
 __all__ = [
     "extract_entities",

--- a/py_name_entity_recognition/models/config.py
+++ b/py_name_entity_recognition/models/config.py
@@ -55,5 +55,5 @@ class ModelConfig(BaseModel):
     class Config:
         """Pydantic model configuration."""
 
-        allow_population_by_field_name = True
+        populate_by_name = True
         extra = "ignore"

--- a/py_name_entity_recognition/models/factory.py
+++ b/py_name_entity_recognition/models/factory.py
@@ -65,7 +65,7 @@ class ModelFactory:
         if config.max_tokens is not None:
             params["max_tokens"] = config.max_tokens
         if config.top_p is not None:
-            model_kwargs["top_p"] = config.top_p
+            params["top_p"] = config.top_p
         if model_kwargs:
             params["model_kwargs"] = model_kwargs
         return AzureChatOpenAI(**params)


### PR DESCRIPTION
Background: install package using sourcecode:

1. top_p in AzureChatOpenAI needs to be explicitly specified in parameters.
2. In __init__.py, use pyproject.toml file to get package version, but the file is not found after installation done. Simplify the version retrieval using importlib.metadata instead of from pyproject.toml file during runtime.
3. According to warning message: update pydantic model config if using pydantic v2